### PR TITLE
ZKR-1237-Extract-the-modulus-from-F

### DIFF
--- a/src/bn256/fr.rs
+++ b/src/bn256/fr.rs
@@ -30,7 +30,7 @@ pub const MODULUS: Fr = Fr([
     0x30644e72e131a029,
 ]);
 
-const MODULUS_STR: &str = "0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001";
+pub const MODULUS_STR: &str = "0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001";
 
 /// INV = -(r^{-1} mod 2^64) mod 2^64
 const INV: u64 = 0xc2e1f593efffffff;

--- a/src/bn256/fr.rs
+++ b/src/bn256/fr.rs
@@ -30,6 +30,7 @@ pub const MODULUS: Fr = Fr([
     0x30644e72e131a029,
 ]);
 
+/// Visibility changed for analyzer
 pub const MODULUS_STR: &str = "0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001";
 
 /// INV = -(r^{-1} mod 2^64) mod 2^64

--- a/src/bn256/mod.rs
+++ b/src/bn256/mod.rs
@@ -3,6 +3,7 @@ mod fq;
 mod fq12;
 mod fq2;
 mod fq6;
+/// Visibility changed for analyzer
 pub mod fr;
 mod curve;
 

--- a/src/bn256/mod.rs
+++ b/src/bn256/mod.rs
@@ -3,7 +3,7 @@ mod fq;
 mod fq12;
 mod fq2;
 mod fq6;
-mod fr;
+pub mod fr;
 mod curve;
 
 #[cfg(all(feature = "asm", target_arch = "x86_64"))]


### PR DESCRIPTION
Change the visibility of module `fr` and the field `MODULUS_STR` inside it to be able to extract modulus from it, to be used in the SMT solver.